### PR TITLE
指定したタイトルのシーズンを作成するrakeタスクの作成

### DIFF
--- a/app/hashes/episode_hash.rb
+++ b/app/hashes/episode_hash.rb
@@ -6,7 +6,7 @@ class EpisodeHash < BaseHash
   end
 
   def nonexistent_episode?(season)
-    DanimeNicoBranchStore.find_season_including_nonexistent_episodes(season)&.episodes&.include?(self)
+    Scraping::DanimeNicoBranchStore.find_season_including_nonexistent_episodes(season)&.episodes&.include?(self)
   end
 
   def update_only_different_title(season)

--- a/app/tasks/data_task.rb
+++ b/app/tasks/data_task.rb
@@ -29,11 +29,15 @@ class DataTask
       target_season_titles.each { |season_title| create_season(initialize_season(season_title)) }
     end
 
+    def create_designated_season(title)
+      logger.debug('selecting seasons now...')
+      create_season(initialize_season(title)) unless already_created_seasons.any? { |season| season.title == title }
+    end
+
     def update_designated_seasons(target_string)
       logger.debug('selecting seasons now...')
       target_seasons =
         already_created_seasons.select { |season| season.title =~ %r(#{Regexp.escape(target_string)}) }
-      target_seasons = [initialize_season(target_string)] unless target_seasons
       target_seasons.each { |target_season| create_season(target_season) }
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,15 @@ seasons_including_nonexistent_episodes:
         id: 1
         episode_no: '第13話'
         title: '特別番組『立花館To Lieあんぐる withエラバレシ』'
+  -
+    id: 5
+    title: 'orange'
+    episodes:
+      -
+        id: 1
+        episode_no: '13'
+        title: 'LAST　LETTER'
+
 seasons_including_different_title_episodes:
   -
     id: 1
@@ -92,3 +101,15 @@ seasons_including_different_title_episodes:
             nico_branch:
               episode_no: '第12話'
               title: '少女終末旅行'
+  -
+          id: 6
+          title: 'TVアニメ「ペルソナ５」'
+          episodes:
+            -
+              id: 1
+              head:
+                episode_no: '#17'
+                title: 'X Day'
+              nico_branch:
+                episode_no: '#17'
+                title: 'TVアニメ「ペルソナ５」'

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -27,10 +27,20 @@ namespace :data do
     execute_task(task.name, create_uncreated_seasons)
   end
 
-  desc 'update designated season data'
-  task designated_seasons: 'db/data' do |task|
-    update_designated_seasons = -> { DataTask.update_designated_seasons(ENV['season_title']) }
-    execute_task(task.name, update_designated_seasons)
+  namespace :designated_season do
+    desc 'create designated season data'
+    task create: 'db/data' do |task|
+      crate_designated_season = -> { DataTask.create_designated_season(ENV['season_title']) }
+      execute_task(task.name, crate_designated_season)
+    end
+  end
+
+  namespace :designated_seasons do
+    desc 'update designated season data'
+    task update: 'db/data' do |task|
+      update_designated_seasons = -> { DataTask.update_designated_seasons(ENV['season_title']) }
+      execute_task(task.name, update_designated_seasons)
+    end
   end
 
   desc 'update on-air season data'


### PR DESCRIPTION
fixes #16 
- [x] タスクの実処理を作成
- [x] rakeタスクを作成
- [x] data:designated_seasonsの修正