### PR TITLE
binをつけないとrakeタスクが落ちる問題を修正

### DIFF
--- a/app/tasks/data_task.rb
+++ b/app/tasks/data_task.rb
@@ -14,6 +14,7 @@ class DataTask
     end
 
     def create_season_list
+      YAMLFile.write(DataTask::SEASON_LIST_PATH, []) unless File.exist?(DataTask::SEASON_LIST_PATH)
       season_list = Scraping::SeasonLineup.execute(YAMLFile.open(DataTask::SEASON_LIST_PATH))
       YAMLFile.write(DataTask::SEASON_LIST_PATH, season_list)
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,50 +1,48 @@
 # frozen_string_literal: true
 
-include TaskExecutable
-
 namespace :data do
-  desc 'create season list'
-  task season_list: DataTask::SEASON_LIST_PATH do |task|
-    create_season_list = -> { DataTask.create_season_list }
-    execute_task(task.name, create_season_list)
+  task setup: :environment do
+    include TaskExecutable
   end
 
-  file DataTask::SEASON_LIST_PATH do
-    YAMLFile.write(DataTask::SEASON_LIST_PATH, [])
+  desc 'create season list'
+  task season_list: :setup do |task|
+    create_season_list = -> { DataTask.create_season_list }
+    execute_task(task.name, create_season_list)
   end
 
   directory 'db/data'
 
   desc 'show list of not watchable seasons'
-  task :not_watchable_season_list do |task|
+  task not_watchable_season_list: :setup do |task|
     get_not_watchable_season_list = -> { DataTask.get_not_watchable_season_list }
     execute_task(task.name, get_not_watchable_season_list)
   end
 
   desc 'create uncreated season data'
-  task uncreated_seasons: 'db/data' do |task|
+  task uncreated_seasons: [:setup, 'db/data'] do |task|
     create_uncreated_seasons = -> { DataTask.create_uncreated_seasons }
     execute_task(task.name, create_uncreated_seasons)
   end
 
   namespace :designated_season do
     desc 'create designated season data'
-    task create: 'db/data' do |task|
-      crate_designated_season = -> { DataTask.create_designated_season(ENV['season_title']) }
+    task :create, ['season_title'] => [:setup, 'db/data'] do |task, args|
+      crate_designated_season = -> { DataTask.create_designated_season(args.season_title) }
       execute_task(task.name, crate_designated_season)
     end
   end
 
   namespace :designated_seasons do
     desc 'update designated season data'
-    task update: 'db/data' do |task|
-      update_designated_seasons = -> { DataTask.update_designated_seasons(ENV['season_title']) }
+    task :update, ['season_title'] => [:setup, 'db/data'] do |task, args|
+      update_designated_seasons = -> { DataTask.update_designated_seasons(args.season_title) }
       execute_task(task.name, update_designated_seasons)
     end
   end
 
   desc 'update on-air season data'
-  task on_air_seasons: 'db/data' do |task|
+  task on_air_seasons: [:setup, 'db/data'] do |task|
     update_on_air_seasons = -> { DataTask.update_on_air_seasons }
     execute_task(task.name, update_on_air_seasons)
   end


### PR DESCRIPTION
- 各rakeタスクの前処理にsetupタスクを追加
  - rakeタスクの前処理を指定する引数には自作クラスが使えないため、タスク本体側にファイル存在有無を確認する処理を移動
- タイトル指定のタスクの引数の指定方法を変更