### PR TITLE
public/manifest.jsonの余分な末尾のカンマを削除

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,15 +5,15 @@
     {
       "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
-      "type":"image/png",
+      "type":"image/png"
     },
     {
       "src": "/android-chrome-512x512.png",
       "sizes": "512x512",
-      "type": "image/png",
+      "type": "image/png"
     }
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "display": "standalone",
+  "display": "standalone"
 }


### PR DESCRIPTION
fixed #332 