### PR TITLE
 ニコニコのサムネイルのURLをhttpsで出力するように修正

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -73,6 +73,10 @@ class Episode < ApplicationRecord
     ].select(&:present?).join('　')
   end
 
+  def thumbnail_https_url
+    thumbnail_url.gsub('http:', 'https:')
+  end
+
   def to_param
     content_id
   end

--- a/app/views/seasons/_episode.html.haml
+++ b/app/views/seasons/_episode.html.haml
@@ -4,7 +4,7 @@
       .col-sm-11.col-12.pl-0
         .season-episodes-item__title-container
           .season-episodes-item__thumbnail
-            = image_tag episode.thumbnail_url, alt: 'Card image cap', class: 'season-episodes-item__image'
+            = image_tag episode.thumbnail_https_url, alt: 'Card image cap', class: 'season-episodes-item__image'
           .season-episodes-item__title
             = episode.full_title(false)
       .d-none.d-sm-flex.col-sm-1.p-0

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -112,4 +112,13 @@ RSpec.describe Episode, type: :model do
       end
     end
   end
+
+  describe '#thumbnail_https_url' do
+    let(:episode) { build(:episode) }
+    let(:thumbnail_https_url) { episode.thumbnail_https_url }
+
+    it 'httpsに変換されたサムネイルのURLを返す' do
+      expect(thumbnail_https_url).to eq 'https://dammy.com?i=1'
+    end
+  end
 end


### PR DESCRIPTION
fixed #337 